### PR TITLE
Fix coefficients in pressure, and temperature for ITU-R P.835

### DIFF
--- a/itur/models/itu835.py
+++ b/itur/models/itu835.py
@@ -179,8 +179,8 @@ class _ITU835_6():
 
     def low_latitude_pressure(self, h):
         """Section 2 of Recommendation ITU-R P.835-6."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1012.0306 - 109.0338 * h + 3.6316 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -213,8 +213,8 @@ class _ITU835_6():
 
     def mid_latitude_pressure_summer(self, h):
         """Section 3.1 of Recommendation ITU-R P.835-6."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(
             np.logical_and((0 <= h), (h <= 10)),
             1012.8186 - 111.5569 * h + 3.8646 * h**2, np.where(
@@ -247,8 +247,8 @@ class _ITU835_6():
 
     def mid_latitude_pressure_winter(self, h):
         """Section 3.2 of Recommendation ITU-R P.835-6."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                     1018.8627 - 124.2954 * h + 4.8307 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -280,8 +280,8 @@ class _ITU835_6():
 
     def high_latitude_pressure_summer(self, h):
         """Section 3.1 of Recommendation ITU-R P.835-6."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1008.0278 - 113.2494 * h + 3.9408 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -312,8 +312,8 @@ class _ITU835_6():
 
     def high_latitude_pressure_winter(self, h):
         """Section 4.2 of Recommendation ITU-R P.835-6."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1010.8828 - 122.2411 * h + 4.554 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -459,8 +459,8 @@ class _ITU835_5():
 
     def low_latitude_pressure(self, h):
         """Section 2 of Recommendation ITU-R P.835-5."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1012.0306 - 109.0338 * h + 3.6316 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -492,8 +492,8 @@ class _ITU835_5():
 
     def mid_latitude_pressure_summer(self, h):
         """Section 3.1 of Recommendation ITU-R P.835-5."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(
                     np.logical_and((0 <= h), (h <= 10)),
                     1012.8186 - 111.5569 * h + 3.8646 * h**2,
@@ -527,8 +527,8 @@ class _ITU835_5():
 
     def mid_latitude_pressure_winter(self, h):
         """Section 3.2 of Recommendation ITU-R P.835-5."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                     1018.8627 - 124.2954 * h + 4.8307 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -560,8 +560,8 @@ class _ITU835_5():
 
     def high_latitude_pressure_summer(self, h):
         """Section 4.1 of Recommendation ITU-R P.835-5."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1008.0278 - 113.2494 * h + 3.9408 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -592,8 +592,8 @@ class _ITU835_5():
 
     def high_latitude_pressure_winter(self, h):
         """Section 3.2 of Recommendation ITU-R P.835-5."""
-        P10 = standard_pressure(10).to(u.hPa).value
-        P72 = standard_pressure(72).to(u.hPa).value
+        P10 = self.standard_pressure(10)
+        P72 = self.standard_pressure(72)
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1010.8828 - 122.2411 * h + 4.554 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),

--- a/itur/models/itu835.py
+++ b/itur/models/itu835.py
@@ -459,8 +459,8 @@ class _ITU835_5():
 
     def low_latitude_pressure(self, h):
         """Section 2 of Recommendation ITU-R P.835-5."""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        P10 = self.standard_pressure([10])[0]
+        P72 = self.standard_pressure([72])[0]
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1012.0306 - 109.0338 * h + 3.6316 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -492,8 +492,8 @@ class _ITU835_5():
 
     def mid_latitude_pressure_summer(self, h):
         """Section 3.1 of Recommendation ITU-R P.835-5."""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        P10 = self.standard_pressure([10])[0]
+        P72 = self.standard_pressure([72])[0]
         return np.where(
                     np.logical_and((0 <= h), (h <= 10)),
                     1012.8186 - 111.5569 * h + 3.8646 * h**2,

--- a/itur/models/itu835.py
+++ b/itur/models/itu835.py
@@ -1,25 +1,34 @@
 # -*- coding: utf-8 -*-
+"""A package that contains the models of ITU-R P.835 Recommendation, Reference Standard Atmospheres.
+
+Available versions:
+       * P.835-6 (12/17) (Current version)
+       * P.835-5 (02/12) (Superseded)
+
+    Not available versions:
+       * P.835-1 (08/94) (Superseded)
+       * P.835-2 (08/97) (Superseded)
+       * P.835-3 (10/99) (Superseded)
+       * P.835-4 (03/05) (Superseded)
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-from itur.utils import prepare_input_array, prepare_output_array,\
-    prepare_quantity
 from astropy import units as u
+
+from itur.utils import (prepare_input_array,
+                        prepare_output_array,
+                        prepare_quantity)
 
 
 class __ITU835__():
-
-    """ Class to model the ITU-R P.835 recommendation.
+    """Class to model the ITU-R P.835 recommendation.
 
     The procedures to compute the reference standard atmosphere parameters
     pressented in these versions are identical to those included in version
-    ITU_T P.835-5. Version 3 includes a dataset with vertical profiles for
-    353 locations over the world using 10 years of radiosonde observations.
-    Version 4 includes another dataset with monthly vertical profiles worldwide
-    (grid of 1.5 by 1.5 deg). None of these are currently implemente but TODO
-    work.
+    ITU_T P.835.
 
     Available versions:
        * P.835-6 (12/17) (Current version)
@@ -30,8 +39,8 @@ class __ITU835__():
        * P.835-2 (08/97) (Superseded)
        * P.835-3 (10/99) (Superseded)
        * P.835-4 (03/05) (Superseded)
-
     """
+
     # This is an abstract class that contains an instance to a version of the
     # ITU-R P.835 recommendation.
 
@@ -70,7 +79,7 @@ class __ITU835__():
     def standard_water_vapour_density(self, h, h_0, rho_0):
         return self.instance.standard_water_vapour_density(h, h_0, rho_0)
 
-    def standard_water_vapour_pressure(self, h, h_0, rho_0):
+    def standard_water_vapour_pressure(self, h, h_0=2, rho_0=7.5):
         return self.instance.standard_water_vapour_pressure(h, h_0, rho_0)
 
 
@@ -147,7 +156,7 @@ class _ITU835_6():
         """
         return rho_0 * np.exp(-h / h_0)
 
-    def standard_water_vapour_pressure(self, h, h_0, rho_0):
+    def standard_water_vapour_pressure(self, h, h_0=2, rho_0=7.5):
         """
 
         """
@@ -158,7 +167,7 @@ class _ITU835_6():
     #  Low latitude standard atmosphere functions  (Section ITU-R P.835-5-2)  #
     @staticmethod
     def low_latitude_temperature(h):
-        """Section 2 of Recommendation ITU-R P.835"""
+        """Section 2 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h < 17)),
                         300.4222 - 6.3533 * h + 0.005886 * h**2,
                np.where(np.logical_and((17 <= h), (h < 47)),
@@ -169,28 +178,28 @@ class _ITU835_6():
                np.where(np.logical_and((80 <= h), (h <= 100)), 184, 184)))))
 
     def low_latitude_pressure(self, h):
-        """Section 2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        """Section 2 of Recommendation ITU-R P.835-6."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1012.0306 - 109.0338 * h + 3.6316 * h ** 2,
-               np.where(np.logical_and( (10 < h), (h <= 72)),
+                        1012.0306 - 109.0338 * h + 3.6316 * h**2,
+               np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
                     P72 * np.exp(-0.165 * (h - 72)), np.nan)))
 
     @staticmethod
     def low_latitude_water_vapour(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h <= 15)), 19.6542 *
                         np.exp(- 0.2313 * h - 0.1122 * h**2 + 0.01351 * h**3 -
                                0.0005923 * h**4), 0)
 
-    # High latitude standard atmosphere functions  (Section ITU-R P.835-5-2)
+    # High latitude standard atmosphere functions  (Section ITU-R P.835-6 5-2)
     # ##
     @staticmethod
     def mid_latitude_temperature_summer(h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h < 10)),
                         286.8374 - 4.7805 * h - 0.1402 * h**2,
                np.where(np.logical_and((10 <= h), (h < 23)), 225,
@@ -203,14 +212,14 @@ class _ITU835_6():
                         171, np.nan))))))
 
     def mid_latitude_pressure_summer(self, h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(
             np.logical_and((0 <= h), (h <= 10)),
-            1008.0278 - 113.2494 * h + 3.9408 * h ** 2, np.where(
+            1012.8186 - 111.5569 * h + 3.8646 * h**2, np.where(
                 np.logical_and((10 < h), (h <= 72)),
-                P10 * np.exp(-0.140 * (h - 10)),
+                P10 * np.exp(-0.147 * (h - 10)),
                 np.where(
                     np.logical_and((72 < h), (h <= 100)),
                     P72 * np.exp(-0.165 * (h - 72)),
@@ -218,17 +227,17 @@ class _ITU835_6():
 
     @staticmethod
     def mid_latitude_water_vapour_summer(h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h <= 15)),
                         8.988 * np.exp(- 0.3614 * h - 0.005402 * h**2 -
                                        0.001955 * h**3), 0)
 
     @staticmethod
     def mid_latitude_temperature_winter(h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
+        """Section 4.2 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h < 8.5)),
-                        257.4345 + 2.3474 * h - 1.5479 * h ** 2 +
-                        0.08473 * h ** 3,
+                        257.4345 + 2.3474 * h - 1.5479 * h**2 +
+                        0.08473 * h**3,
                np.where(np.logical_and((8.5 <= h), (h < 30)), 217.5,
                np.where(np.logical_and((30 <= h), (h < 50)),
                         217.5 + (h - 30) * 2.125,
@@ -237,19 +246,19 @@ class _ITU835_6():
                         260 - (h - 54) * 1.667, np.nan)))))
 
     def mid_latitude_pressure_winter(self, h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        """Section 3.2 of Recommendation ITU-R P.835-6."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1010.8828 - 122.2411 * h + 4.554 * h ** 2,
+                    1018.8627 - 124.2954 * h + 4.8307 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
-                        P72 * np.exp(-0.150 * (h - 72)), np.nan)))
+                        P72 * np.exp(-0.155 * (h - 72)), np.nan)))
 
     @staticmethod
     def mid_latitude_water_vapour_winter(h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
+        """Section 3.2 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1.2319 * np.exp(0.07481 * h - 0.0981 * h**2 +
                                         0.00281 * h**3), 0)
@@ -257,9 +266,9 @@ class _ITU835_6():
     #  Mid latitude standard atmosphere functions  (Section ITU-R P.835-5-2)  #
     @staticmethod
     def high_latitude_temperature_summer(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h < 13)),
-                        294.9838 - 5.2159 * h - 9.07109 * h ** 2,
+                        294.9838 - 5.2159 * h - 9.07109 * h**2,
                np.where(np.logical_and((13 <= h), (h < 17)), 215,
                np.where(np.logical_and((17 <= h), (h < 47)),
                         215 * np.exp((h - 17) * 0.008128),
@@ -270,26 +279,26 @@ class _ITU835_6():
                         175, np.nan))))))
 
     def high_latitude_pressure_summer(self, h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1012.8186 - 111.5569 * h + 3.8646 * h ** 2,
+                        1008.0278 - 113.2494 * h + 3.9408 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
-                        P10 * np.exp(-0.147 * (h - 10)),
+                        P10 * np.exp(-0.140 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
                         P72 * np.exp(-0.165 * (h - 72)), np.nan)))
 
     @staticmethod
     def high_latitude_water_vapour_summer(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h <= 15)),
                         14.3542 * np.exp(- 0.4174 * h - 0.02290 * h**2 +
                                          0.001007 * h**3), 0)
 
     @staticmethod
     def high_latitude_temperature_winter(h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
+        """Section 4.2 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and((0 <= h), (h < 10)),
                         272.7241 - 3.6217 * h - 0.1759 * h**2,
                np.where(np.logical_and((10 <= h), (h < 33)), 218,
@@ -302,67 +311,76 @@ class _ITU835_6():
                         210, np.nan))))))
 
     def high_latitude_pressure_winter(self, h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        """Section 4.2 of Recommendation ITU-R P.835-6."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1018.8627 - 124.2954 * h + 4.8307 * h ** 2,
+                        1010.8828 - 122.2411 * h + 4.554 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
-                        P72 * np.exp(-0.155 * (h - 72)), np.nan)))
+                        P72 * np.exp(-0.150 * (h - 72)), np.nan)))
 
     @staticmethod
     def high_latitude_water_vapour_winter(h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
+        """Section 4.2 of Recommendation ITU-R P.835-6."""
         return np.where(np.logical_and(0 <= h, h <= 10),
                         3.4742 * np.exp(- 0.2697 * h - 0.03604 * h**2 +
                                         0.0004489 * h**3), 0)
 
     def temperature(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2 of Recommendation ITU-R P.835-6."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_temperature(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_temperature_summer(h),
                     self.high_latitude_temperature_summer(h)))
-        else:
+        elif season == 'winter':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_temperature(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_temperature_winter(h),
                     self.high_latitude_temperature_winter(h)))
+        else:
+            raise ValueError("The value for argument 'season' is not correct."
+                             "Valid values are 'summer' and 'winter'.")
 
     def pressure(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2 of Recommendation ITU-R P.835-6."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_pressure(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_pressure_summer(h),
                     self.high_latitude_pressure_summer(h)))
-        else:
+        elif season == 'winter':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_pressure(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_pressure_winter(h),
                     self.high_latitude_pressure_winter(h)))
+        else:
+            raise ValueError("The value for argument 'season' is not correct."
+                             "Valid values are 'summer' and 'winter'")
 
     def water_vapour_density(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2 of Recommendation ITU-R P.835-6."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_water_vapour(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_water_vapour_summer(h),
                     self.high_latitude_water_vapour_summer(h)))
-        else:
+        elif season == 'winter':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_water_vapour(h),
                 np.where(
                     np.abs(lat) < 45, self.mid_latitude_water_vapour_winter(h),
                     self.high_latitude_water_vapour_winter(h)))
+        else:
+            raise ValueError("The value for argument 'season' is not correct."
+                             "Valid values are 'summer' and 'winter'")
 
 
 class _ITU835_5():
@@ -376,7 +394,6 @@ class _ITU835_5():
     @staticmethod
     def standard_temperature(h, T_0=288.15):
         """
-
         """
         H = np.array([0, 11, 20, 32, 47, 51, 71, 85])
         T = np.array([0, -65, -65, -53, -11, -11, -67, -95]) + T_0
@@ -386,7 +403,6 @@ class _ITU835_5():
     @staticmethod
     def standard_pressure(h, T_0=288.15, P_0=1013.25):
         """
-
         """
         H = [0, 11, 20, 32, 47, 51, 71, 85]
         L = [-6.5, 0, 1, 2.8, 0, -2.8, -2]
@@ -420,7 +436,7 @@ class _ITU835_5():
         """
         return rho_0 * np.exp(-h / h_0)
 
-    def standard_water_vapour_pressure(self, h, h_0, rho_0):
+    def standard_water_vapour_pressure(self, h, h_0=2, rho_0=7.5):
         """
 
         """
@@ -428,10 +444,10 @@ class _ITU835_5():
         T_h = self.standard_temperature(h)
         return rho_h * T_h / 216.7
 
-    #  Low latitude standard atmosphere functions  (Section ITU-R P.835-5-2)  #
+    #  Low latitude standard atmosphere functions  (Section ITU-R P.835 5-2)  #
     @staticmethod
     def low_latitude_temperature(h):
-        """Section 2 of Recommendation ITU-R P.835"""
+        """Section 2 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h < 17)),
                         300.4222 - 6.3533 * h + 0.005886 * h**2,
                np.where(np.logical_and((17 <= h), (h < 47)),
@@ -442,19 +458,19 @@ class _ITU835_5():
                np.where(np.logical_and((80 <= h), (h <= 100)), 184, np.nan)))))
 
     def low_latitude_pressure(self, h):
-        """Section 2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure([10])[0]
-        P72 = self.standard_pressure([72])[0]
+        """Section 2 of Recommendation ITU-R P.835-5."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1012.0306 - 109.0338 * h + 3.6316 * h ** 2,
-               np.where(np.logical_and( (10 < h), (h <= 72)),
+                        1012.0306 - 109.0338 * h + 3.6316 * h**2,
+               np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
                     P72 * np.exp(-0.165 * (h - 72)), np.nan)))
 
     @staticmethod
     def low_latitude_water_vapour(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h <= 15)), 19.6542 *
                         np.exp(- 0.2313 * h - 0.1122 * h**2 + 0.01351 * h**3 -
                                0.0005923 * h**4), 0)
@@ -462,7 +478,7 @@ class _ITU835_5():
     # High latitude standard atmosphere functions  (Section ITU-R P.835-5-2)  #
     @staticmethod
     def mid_latitude_temperature_summer(h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h < 10)),
                         286.8374 - 4.7805 * h - 0.1402 * h**2,
                np.where(np.logical_and((10 <= h), (h < 23)), 225,
@@ -475,32 +491,33 @@ class _ITU835_5():
                         171, np.nan))))))
 
     def mid_latitude_pressure_summer(self, h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure([10])[0]
-        P72 = self.standard_pressure([72])[0]
+        """Section 3.1 of Recommendation ITU-R P.835-5."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(
-            np.logical_and((0 <= h), (h <= 10)),
-            1008.0278 - 113.2494 * h + 3.9408 * h ** 2, np.where(
-                np.logical_and((10 < h), (h <= 72)),
-                P10 * np.exp(-0.140 * (h - 10)),
-                np.where(
-                    np.logical_and((72 < h), (h <= 100)),
-                    P72 * np.exp(-0.165 * (h - 72)),
-                    np.nan)))
+                    np.logical_and((0 <= h), (h <= 10)),
+                    1012.8186 - 111.5569 * h + 3.8646 * h**2,
+               np.where(
+                   np.logical_and((10 < h), (h <= 72)),
+                   P10 * np.exp(-0.147 * (h - 10)),
+               np.where(
+                   np.logical_and((72 < h), (h <= 100)),
+                   P72 * np.exp(-0.165 * (h - 72)),
+                   np.nan)))
 
     @staticmethod
     def mid_latitude_water_vapour_summer(h):
-        """Section 4.1 of Recommendation ITU-R P.835"""
+        """Section 3.1 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h <= 15)),
                         8.988 * np.exp(- 0.3614 * h - 0.005402 * h**2 -
                                        0.001955 * h**3), 0)
 
     @staticmethod
     def mid_latitude_temperature_winter(h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h < 8.5)),
-                        257.4345 + 2.3474 * h - 1.5479 * h ** 2 +
-                        0.08473 * h ** 3,
+                        257.4345 + 2.3474 * h - 1.5479 * h**2 +
+                        0.08473 * h**3,
                np.where(np.logical_and((8.5 <= h), (h < 30)), 217.5,
                np.where(np.logical_and((30 <= h), (h < 50)),
                         217.5 + (h - 30) * 2.125,
@@ -509,19 +526,19 @@ class _ITU835_5():
                         260 - (h - 54) * 1.667, np.nan)))))
 
     def mid_latitude_pressure_winter(self, h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure([10])[0]
-        P72 = self.standard_pressure([72])[0]
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1010.8828 - 122.2411 * h + 4.554 * h ** 2,
+                    1018.8627 - 124.2954 * h + 4.8307 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
-                        P72 * np.exp(-0.150 * (h - 72)), np.nan)))
+                        P72 * np.exp(-0.155 * (h - 72)), np.nan)))
 
     @staticmethod
     def mid_latitude_water_vapour_winter(h):
-        """Section 4.2 of Recommendation ITU-R P.835"""
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1.2319 * np.exp(0.07481 * h - 0.0981 * h**2 +
                                         0.00281 * h**3), 0)
@@ -529,9 +546,9 @@ class _ITU835_5():
     #  Mid latitude standard atmosphere functions  (Section ITU-R P.835-5-2)  #
     @staticmethod
     def high_latitude_temperature_summer(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 4.1 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h < 13)),
-                        294.9838 - 5.2159 * h - 9.07109 * h ** 2,
+                        294.9838 - 5.2159 * h - 9.07109 * h**2,
                np.where(np.logical_and((13 <= h), (h < 17)), 215,
                np.where(np.logical_and((17 <= h), (h < 47)),
                         215 * np.exp((h - 17) * 0.008128),
@@ -542,26 +559,26 @@ class _ITU835_5():
                         175, np.nan))))))
 
     def high_latitude_pressure_summer(self, h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure([10])[0]
-        P72 = self.standard_pressure([72])[0]
+        """Section 4.1 of Recommendation ITU-R P.835-5."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1012.8186 - 111.5569 * h + 3.8646 * h ** 2,
+                        1008.0278 - 113.2494 * h + 3.9408 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
-                        P10 * np.exp(-0.147 * (h - 10)),
+                        P10 * np.exp(-0.140 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
                         P72 * np.exp(-0.165 * (h - 72)), np.nan)))
 
     @staticmethod
     def high_latitude_water_vapour_summer(h):
-        """Section 3.1 of Recommendation ITU-R P.835"""
+        """Section 4.1 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h <= 15)),
                         14.3542 * np.exp(- 0.4174 * h - 0.02290 * h**2 +
                                          0.001007 * h**3), 0)
 
     @staticmethod
     def high_latitude_temperature_winter(h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and((0 <= h), (h < 10)),
                         272.7241 - 3.6217 * h - 0.1759 * h**2,
                np.where(np.logical_and((10 <= h), (h < 33)), 218,
@@ -574,25 +591,25 @@ class _ITU835_5():
                         210, np.nan))))))
 
     def high_latitude_pressure_winter(self, h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
-        P10 = self.standard_pressure([10])[0]
-        P72 = self.standard_pressure([72])[0]
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
+        P10 = standard_pressure(10).to(u.hPa).value
+        P72 = standard_pressure(72).to(u.hPa).value
         return np.where(np.logical_and((0 <= h), (h <= 10)),
-                        1018.8627 - 124.2954 * h + 4.8307 * h ** 2,
+                        1010.8828 - 122.2411 * h + 4.554 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
                         P10 * np.exp(-0.147 * (h - 10)),
                np.where(np.logical_and((72 < h), (h <= 100)),
-                        P72 * np.exp(-0.155 * (h - 72)), np.nan)))
+                        P72 * np.exp(-0.150 * (h - 72)), np.nan)))
 
     @staticmethod
     def high_latitude_water_vapour_winter(h):
-        """Section 3.2 of Recommendation ITU-R P.835"""
+        """Section 3.2 of Recommendation ITU-R P.835-5."""
         return np.where(np.logical_and(0 <= h, h <= 10),
                         3.4742 * np.exp(- 0.2697 * h - 0.03604 * h**2 +
                                         0.0004489 * h**3), 0)
 
     def temperature(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2 of Recommendation ITU-R P.835-5."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_temperature(h),
@@ -607,7 +624,7 @@ class _ITU835_5():
                     self.high_latitude_temperature_winter(h)))
 
     def pressure(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2, 3, 4 of Recommendation ITU-R P.835-5."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_pressure(h),
@@ -622,7 +639,7 @@ class _ITU835_5():
                     self.high_latitude_pressure_winter(h)))
 
     def water_vapour_density(self, lat, h, season='summer'):
-        """ Section 2 of Recommendation ITU-R P.835"""
+        """ Section 2 of Recommendation ITU-R P.835-5."""
         if season == 'summer':
             return np.where(
                 np.abs(lat) < 22, self.low_latitude_water_vapour(h),
@@ -910,9 +927,7 @@ def standard_water_vapour_density(h, h_0=2, rho_0=7.5):
 
 
 def standard_water_vapour_pressure(h, h_0=2, rho_0=7.5):
-    """
-    Method to compute the water vapour pressure of an standard atmosphere at
-    a given height.
+    """Compute the water vapour pressure of standard atmosphere at height.
 
     The reference standard atmosphere is based on the United States Standard
     Atmosphere, 1976, in which the atmosphere is divided into seven successive

--- a/itur/models/itu835.py
+++ b/itur/models/itu835.py
@@ -527,8 +527,8 @@ class _ITU835_5():
 
     def mid_latitude_pressure_winter(self, h):
         """Section 3.2 of Recommendation ITU-R P.835-5."""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        P10 = self.standard_pressure([10])[0]
+        P72 = self.standard_pressure([72])[0]
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                     1018.8627 - 124.2954 * h + 4.8307 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -560,8 +560,8 @@ class _ITU835_5():
 
     def high_latitude_pressure_summer(self, h):
         """Section 4.1 of Recommendation ITU-R P.835-5."""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        P10 = self.standard_pressure([10])[0]
+        P72 = self.standard_pressure([72])[0]
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1008.0278 - 113.2494 * h + 3.9408 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),
@@ -592,8 +592,8 @@ class _ITU835_5():
 
     def high_latitude_pressure_winter(self, h):
         """Section 3.2 of Recommendation ITU-R P.835-5."""
-        P10 = self.standard_pressure(10)
-        P72 = self.standard_pressure(72)
+        P10 = self.standard_pressure([10])[0]
+        P72 = self.standard_pressure([72])[0]
         return np.where(np.logical_and((0 <= h), (h <= 10)),
                         1010.8828 - 122.2411 * h + 4.554 * h**2,
                np.where(np.logical_and((10 < h), (h <= 72)),


### PR DESCRIPTION
- Add default values for `standard_water_vapour_pressure`
- Updat coefficients for `mid_latitude_pressure_summer`, and `mid_latitude_pressure_winter`
- Updat coefficients for `high_latitude_pressure_summer`, and `high_latitude_pressure_winter`
- Add error if user introduces wrong season (i.e., something other than 'summer' or 'winter')

Closes #22 